### PR TITLE
fix wiener process formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ def model_simulation (alpha_c, alpha_i, beta, delta_c, delta_i, tau, dt=DT, var=
         evidence = beta*alpha/2 - (1-beta)*alpha/2 # start our evidence at initial-bias beta
         np.random.seed(n)
         while evidence < alpha and evidence > -alpha: # keep accumulating evidence until you reach a threshold
-            evidence += delta*dt + np.random.choice(updates) # add one of the many possible updates to evidence
+            evidence += delta*dt + np.random.choice(updates) * np.sqrt(dt) # add one of the many possible updates to evidence
             t += dt # increment time by the unit dt
         if evidence > alpha:
             choicelist[n] = 1 # choose the upper threshold action
@@ -380,7 +380,7 @@ np.random.seed(n)
 We then accumulate evidence by the average rate `delta` scaled by the time increment `dt` and adding some noise sampled from `updates`. We also increase time by the time increment `dt`. This process continues until evidence passes one of the thresholds. 
 ```py
 while evidence < alpha/2 and evidence > -alpha/2: # keep accumulating evidence until you reach a threshold
-      evidence += delta*dt + np.random.choice(updates) # add one of the many possible updates to evidence
+      evidence += delta*dt + np.random.choice(updates) * np.sqrt(dt) # add one of the many possible updates to evidence
       t += dt # increment time by the unit dt
 ```
 

--- a/flexddm/models/DMC.py
+++ b/flexddm/models/DMC.py
@@ -94,7 +94,7 @@ class DMC (Model):
                 else:
                     delta = (-peak_amplitude * np.exp(-(t / characteristic_time)) *
                             np.power(((t * np.exp(1)) / ((shape - 1) * characteristic_time)), (shape - 1)) * (((shape - 1) / t) - (1 / characteristic_time))) + mu_c
-                evidence += delta*dt + np.random.choice(update_jitter)
+                evidence += delta*dt + np.random.choice(update_jitter) * np.sqrt(dt)
                 t += dt # increment time by the unit dt
                 if evidence > alpha/2:
                     choicelist[n] = 1

--- a/flexddm/models/DMC.py
+++ b/flexddm/models/DMC.py
@@ -57,7 +57,7 @@ class DMC (Model):
 
 
     @nb.jit(nopython=True, cache=True, parallel=False, fastmath=True, nogil=True)
-    def model_simulation(alpha, beta, mu_c, shape, characteristic_time, peak_amplitude, tau, dt=DT, var=VAR, nTrials=NTRIALS, noiseseed=NOISESEED,):
+    def model_simulation(alpha, beta, mu_c, shape, characteristic_time, peak_amplitude, tau, dt=DT, var=VAR, nTrials=NTRIALS, noiseseed=NOISESEED):
         """
         Performs simulations for DMC model. 
         @alpha (float): boundary separation
@@ -67,10 +67,10 @@ class DMC (Model):
         @characteristic_time (float): duration of the automatic process
         @peak_amplitude (float): amplitude of automatic activation
         @tau (float): non-decision time
-        @dt (float): change in time 
-        @var (float): variance
-        @nTrials (int): number of trials
-        @noiseseed (int): random seed for noise consistency
+        @dt (float): change in time (default: DT)
+        @var (float): variance (default: VAR)
+        @nTrials (int): number of trials (default: NTRIALS)
+        @noiseseed (int): random seed for noise consistency (default: NOISESEED)
         """
 
         choicelist = [np.nan]*nTrials
@@ -104,5 +104,3 @@ class DMC (Model):
                     rtlist[n] = t
 
         return (np.arange(1, nTrials+1), choicelist, rtlist, congruencylist)
-    
-    

--- a/flexddm/models/DMCfs.py
+++ b/flexddm/models/DMCfs.py
@@ -94,7 +94,7 @@ class DMCfs(Model):
                 else:
                     delta = (-peak_amplitude * np.exp(-(t / characteristic_time)) *
                             np.power(((t * np.exp(1)) / ((shape - 1) * characteristic_time)), (shape - 1)) * (((shape - 1) / t) - (1 / characteristic_time))) + mu_c
-                evidence += delta*dt + np.random.choice(update_jitter)
+                evidence += delta*dt + np.random.choice(update_jitter) * np.sqrt(dt)
                 t += dt # increment time by the unit dt
                 if evidence > alpha/2:
                     choicelist[n] = 1

--- a/flexddm/models/DMCfs.py
+++ b/flexddm/models/DMCfs.py
@@ -56,13 +56,12 @@ class DMCfs(Model):
 
 
     @nb.jit(nopython=True, cache=True, parallel=False, fastmath=True, nogil=True)
-    def model_simulation(alpha, beta, mu_c, characteristic_time, peak_amplitude, tau, dt=DT, var=VAR, nTrials=NTRIALS, noiseseed=NOISESEED,):
+    def model_simulation(alpha, beta, mu_c, characteristic_time, peak_amplitude, tau, dt=DT, var=VAR, nTrials=NTRIALS, noiseseed=NOISESEED):
         """
         Performs simulations for DMC model. 
         @alpha (float): boundary separation
         @beta (float): initial bias
         @mu_c (float): drift rate of the controlled process
-        @shape (float): shape parameter of gamma distribution function used to model the time-course of automatic activation 
         @characteristic_time (float): duration of the automatic process
         @peak_amplitude (float): amplitude of automatic activation
         @tau (float): non-decision time

--- a/flexddm/models/DSTP.py
+++ b/flexddm/models/DSTP.py
@@ -95,8 +95,8 @@ class DSTP(Model):
             evidenceRS1 = betaRS*alphaRS - (1-betaRS)*alphaRS
             np.random.seed(n)
             while (evidenceSS < alphaSS/2 and evidenceSS > -alphaSS/2) or (evidenceRS1 < alphaRS/2 and evidenceRS1 > -alphaRS/2): # keep accumulating evidence until you reach a threshold
-                evidenceSS += deltaSS*dt + np.random.choice(update_jitter) # add one of the many possible updates to evidence
-                evidenceRS1 += deltaRS1*dt + np.random.choice(update_jitter)
+                evidenceSS += deltaSS*dt + np.random.choice(update_jitter) * np.sqrt(dt) # add one of the many possible updates to evidence
+                evidenceRS1 += deltaRS1*dt + np.random.choice(update_jitter) * np.sqrt(dt)
                 t += dt # increment time by the unit dt
             if evidenceRS1 > alphaRS/2:
                 choicelist[n] = 1 # choose the upper threshold action
@@ -113,7 +113,7 @@ class DSTP(Model):
                     deltaRS = -1 * deltaRS
                 evidenceRS2 = evidenceRS1 # start where you left off from RS1
                 while (evidenceRS2 < alphaRS/2 and evidenceRS2 > -alphaRS/2): # keep accumulating evidence until you reach a threshold
-                    evidenceRS2 += deltaRS*dt + np.random.choice(update_jitter)
+                    evidenceRS2 += deltaRS*dt + np.random.choice(update_jitter) * np.sqrt(dt)
                     t += dt # increment time by the unit dt
                 if evidenceRS2 > alphaRS/2:
                     choicelist[n] = 1 # choose the upper threshold action

--- a/flexddm/models/DSTPit.py
+++ b/flexddm/models/DSTPit.py
@@ -65,7 +65,7 @@ class DSTPit(Model):
         Performs simulations for DSTP model.
         @alphaSS (float): boundary separation for stimulus selection phase
         @betaSS (float): initial bias for stimulus selection phase
-        @deltaSS (float): drift rate for stimulus selection phase
+        @delta_flanker_deltaSS_ratio (float): drift rate for flanker arrows during response selection BEFORE stimulus is selected, which is calculated as delta_flanker = deltaSS * delta_flanker_deltaSS_ratio
         @alphaRS (float): boundary separation for response selection phase 
         @betaRS (float): inital bias for response selection phase 
         @delta_target (float): drift rate for target arrow during response selection BEFORE stimulus is selected 

--- a/flexddm/models/DSTPit.py
+++ b/flexddm/models/DSTPit.py
@@ -96,8 +96,8 @@ class DSTPit(Model):
             evidenceRS1 = betaRS*alphaRS - (1-betaRS)*alphaRS
             np.random.seed(n)
             while (evidenceSS < alphaSS/2 and evidenceSS > -alphaSS/2) or (evidenceRS1 < alphaRS/2 and evidenceRS1 > -alphaRS/2): # keep accumulating evidence until you reach a threshold
-                evidenceSS += deltaSS*dt + np.random.choice(update_jitter) # add one of the many possible updates to evidence
-                evidenceRS1 += deltaRS1*dt + np.random.choice(update_jitter)
+                evidenceSS += deltaSS*dt + np.random.choice(update_jitter) * np.sqrt(dt) # add one of the many possible updates to evidence
+                evidenceRS1 += deltaRS1*dt + np.random.choice(update_jitter) * np.sqrt(dt)
                 t += dt # increment time by the unit dt
             if evidenceRS1 > alphaRS/2:
                 choicelist[n] = 1 # choose the upper threshold action
@@ -114,7 +114,7 @@ class DSTPit(Model):
                     deltaRS = -1 * deltaRS
                 evidenceRS2 = evidenceRS1 # start where you left off from RS1
                 while (evidenceRS2 < alphaRS/2 and evidenceRS2 > -alphaRS/2): # keep accumulating evidence until you reach a threshold
-                    evidenceRS2 += deltaRS*dt + np.random.choice(update_jitter)
+                    evidenceRS2 += deltaRS*dt + np.random.choice(update_jitter) * np.sqrt(dt)
                     t += dt # increment time by the unit dt
                 if evidenceRS2 > alphaRS/2:
                     choicelist[n] = 1 # choose the upper threshold action

--- a/flexddm/models/SSP.py
+++ b/flexddm/models/SSP.py
@@ -94,7 +94,7 @@ class SSP(Model):
                     delta = s_ta*p - s_fl*p
                 else:
                     delta = s_ta*p + s_fl*p
-                evidence += (delta*dt + np.random.choice(noise)) # add one of the many possible updates to evidence
+                evidence += (delta*dt + np.random.choice(noise) * np.sqrt(dt)) # add one of the many possible updates to evidence
                 t += dt 
             if evidence > alpha/2:
                 choicelist[n] = 1 # choose the upper threshold action

--- a/flexddm/models/SSPit.py
+++ b/flexddm/models/SSPit.py
@@ -91,7 +91,7 @@ class SSPit(Model):
                     delta = s_ta*p - s_fl*p
                 else:
                     delta = s_ta*p + s_fl*p
-                evidence += (delta*dt + np.random.choice(noise)) # add one of the many possible updates to evidence
+                evidence += (delta*dt + np.random.choice(noise) * np.sqrt(dt)) # add one of the many possible updates to evidence
                 t += dt 
             if evidence > alpha/2:
                 choicelist[n] = 1 # choose the upper threshold action

--- a/flexddm/models/SSPit.py
+++ b/flexddm/models/SSPit.py
@@ -56,7 +56,7 @@ class SSPit(Model):
     @nb.jit(nopython=True, cache=True, parallel=False, fastmath=True, nogil=True)
     def model_simulation(alpha, beta, p, sd_0_sd_r_ratio, tau, dt=DT, var=VAR, nTrials=NTRIALS, noiseseed=NOISESEED):
         """
-        Performs simulations for SSP model.
+        Performs simulations for SSPit model.
         @alpha (float): boundary separation
         @beta (float): initial bias
         @p (float): perceptual input of the stimulus

--- a/flexddm/models/StandardDDM.py
+++ b/flexddm/models/StandardDDM.py
@@ -86,7 +86,7 @@ class StandardDDM(Model):
             evidence = beta*alpha - (1-beta)*alpha # start our evidence at initial-bias beta
             np.random.seed(n)
             while evidence < alpha/2 and evidence > -alpha/2: # keep accumulating evidence until you reach a threshold
-                evidence += delta*dt + np.random.choice(updates) # add one of the many possible updates to evidence
+                evidence += delta*dt + np.random.choice(updates) * np.sqrt(dt) # add one of the many possible updates to evidence
                 t += dt # increment time by the unit dt
             if evidence > alpha:
                 choicelist[n] = 1 # choose the upper threshold action

--- a/flexddm/models/mDMC.py
+++ b/flexddm/models/mDMC.py
@@ -99,7 +99,7 @@ class mDMC(Model):
                 else:
                     delta = (-peak_amplitude * np.exp(-(t / characteristic_time)) *
                             np.power(((t * np.exp(1)) / ((shape - 1) * characteristic_time)), (shape - 1)) * (((shape - 1) / t) - (1 / characteristic_time))) + mu_c
-                delta_noise = np.random.choice(update_jitter)
+                delta_noise = np.random.choice(update_jitter) * np.sqrt(dt)
                 delta_noise = delta_noise*(np.exp(-1*(eta_r/2)*((t-tau))))
                 
                 evidence += delta*dt + delta_noise

--- a/flexddm/models/mDMC.py
+++ b/flexddm/models/mDMC.py
@@ -65,7 +65,8 @@ class mDMC(Model):
         Performs simulations for DMC model. 
         @alpha (float): boundary separation
         @beta (float): initial bias
-        @mu_c (float): drift rate of the controlled process
+        @eta (float): drift rate modulation by congruency
+        @eta_r (float): drift rate modulation by response
         @shape (float): shape parameter of gamma distribution function used to model the time-course of automatic activation 
         @characteristic_time (float): duration of the automatic process
         @peak_amplitude (float): amplitude of automatic activation

--- a/flexddm/models/mDMCfs.py
+++ b/flexddm/models/mDMCfs.py
@@ -97,7 +97,7 @@ class mDMCfs(Model):
                 else:
                     delta = (-peak_amplitude * np.exp(-(t / characteristic_time)) *
                             np.power(((t * np.exp(1)) / ((shape - 1) * characteristic_time)), (shape - 1)) * (((shape - 1) / t) - (1 / characteristic_time))) + mu_c
-                delta_noise = np.random.choice(update_jitter)
+                delta_noise = np.random.choice(update_jitter) * np.sqrt(dt)
                 delta_noise = delta_noise*(np.exp(-1*(eta_r/2)*((t-tau))))
                 
                 evidence += delta*dt + delta_noise

--- a/flexddm/models/mDMCfs.py
+++ b/flexddm/models/mDMCfs.py
@@ -63,8 +63,8 @@ class mDMCfs(Model):
         Performs simulations for DMC model. 
         @alpha (float): boundary separation
         @beta (float): initial bias
-        @mu_c (float): drift rate of the controlled process
-        @shape (float): shape parameter of gamma distribution function used to model the time-course of automatic activation 
+        @eta (float): drift rate modulation by congruency
+        @eta_r (float): drift rate modulation by response
         @characteristic_time (float): duration of the automatic process
         @peak_amplitude (float): amplitude of automatic activation
         @tau (float): non-decision time

--- a/flexddm/models/mDSTP.py
+++ b/flexddm/models/mDSTP.py
@@ -104,8 +104,8 @@ class mDSTP(Model):
             evidenceRS1 = betaRS*alphaRS - (1-betaRS)*alphaRS
             np.random.seed(n)
             while (evidenceSS < alphaSS/2 and evidenceSS > -alphaSS/2) or (evidenceRS1 < alphaRS/2 and evidenceRS1 > -alphaRS/2): # keep accumulating evidence until you reach a threshold
-                delta_noise_SS = np.random.choice(update_jitter_SS)
-                delta_noise_RS1 = np.random.choice(update_jitter_RS1)
+                delta_noise_SS = np.random.choice(update_jitter_SS) * np.sqrt(dt)
+                delta_noise_RS1 = np.random.choice(update_jitter_RS1) * np.sqrt(dt)
                 delta_noise_SS = delta_noise_SS*(np.exp(-1*(eta_r/2)*((t-tau))))
                 delta_noise_RS1 = delta_noise_RS1*(np.exp(-1*(eta_r/2)*((t-tau))))
                 evidenceSS += deltaSS*dt + delta_noise_SS # add one of the many possible updates to evidence
@@ -126,7 +126,7 @@ class mDSTP(Model):
                     deltaRS = -1 * deltaRS
                 evidenceRS2 = evidenceRS1 # start where you left off from RS1
                 while (evidenceRS2 < alphaRS/2 and evidenceRS2 > -alphaRS/2): # keep accumulating evidence until you reach a threshold
-                    delta_noise_RS2 = np.random.choice(update_jitter_RS2)
+                    delta_noise_RS2 = np.random.choice(update_jitter_RS2) * np.sqrt(dt)
                     delta_noise_RS2 = delta_noise_RS2*(np.exp(-1*(eta_r/2)*((t-tau))))
                     evidenceRS2 += deltaRS*dt + delta_noise_RS2
                     t += dt # increment time by the unit dt

--- a/flexddm/models/mDSTP.py
+++ b/flexddm/models/mDSTP.py
@@ -67,12 +67,12 @@ class mDSTP(Model):
         Performs simulations for DSTP model.
         @alphaSS (float): boundary separation for stimulus selection phase
         @betaSS (float): initial bias for stimulus selection phase
-        @deltaSS (float): drift rate for stimulus selection phase
+        @etaSS (float): scaling factor for stimulus selection noise
         @alphaRS (float): boundary separation for response selection phase 
-        @betaRS (float): inital bias for response selection phase 
-        @delta_target (float): drift rate for target arrow during response selection BEFORE stimulus is selected 
-        @delta_flanker (float): drift rate for flanker arrows during response selection BEFORE stimulus is selected
-        @deltaRS (float): drift rate for the reponse selection phase after a stimulus (either flanker or target) has been selected
+        @betaRS (float): initial bias for response selection phase 
+        @etaS1 (float): scaling factor for response selection noise (phase 1)
+        @etaS2 (float): scaling factor for response selection noise (phase 2)
+        @eta_r (float): decay rate for noise scaling
         @tau (float): non-decision time
         @dt (float): change in time 
         @var (float): variance

--- a/flexddm/models/mDSTPit.py
+++ b/flexddm/models/mDSTPit.py
@@ -105,8 +105,8 @@ class mDSTP(Model):
             evidenceRS1 = betaRS*alphaRS - (1-betaRS)*alphaRS
             np.random.seed(n)
             while (evidenceSS < alphaSS/2 and evidenceSS > -alphaSS/2) or (evidenceRS1 < alphaRS/2 and evidenceRS1 > -alphaRS/2): # keep accumulating evidence until you reach a threshold
-                delta_noise_SS = np.random.choice(update_jitter_SS)
-                delta_noise_RS1 = np.random.choice(update_jitter_RS1)
+                delta_noise_SS = np.random.choice(update_jitter_SS) * np.sqrt(dt)
+                delta_noise_RS1 = np.random.choice(update_jitter_RS1) * np.sqrt(dt)
                 delta_noise_SS = delta_noise_SS*(np.exp(-1*(eta_r/2)*((t-tau))))
                 delta_noise_RS1 = delta_noise_RS1*(np.exp(-1*(eta_r/2)*((t-tau))))
                 evidenceSS += deltaSS*dt + delta_noise_SS # add one of the many possible updates to evidence
@@ -127,7 +127,7 @@ class mDSTP(Model):
                     deltaRS = -1 * deltaRS
                 evidenceRS2 = evidenceRS1 # start where you left off from RS1
                 while (evidenceRS2 < alphaRS/2 and evidenceRS2 > -alphaRS/2): # keep accumulating evidence until you reach a threshold
-                    delta_noise_RS2 = np.random.choice(update_jitter_RS2)
+                    delta_noise_RS2 = np.random.choice(update_jitter_RS2) * np.sqrt(dt)
                     delta_noise_RS2 = delta_noise_RS2*(np.exp(-1*(eta_r/2)*((t-tau))))
                     evidenceRS2 += deltaRS*dt + delta_noise_RS2
                     t += dt # increment time by the unit dt

--- a/flexddm/models/mDSTPit.py
+++ b/flexddm/models/mDSTPit.py
@@ -68,12 +68,12 @@ class mDSTP(Model):
         Performs simulations for DSTP model.
         @alphaSS (float): boundary separation for stimulus selection phase
         @betaSS (float): initial bias for stimulus selection phase
-        @deltaSS (float): drift rate for stimulus selection phase
+        @etaSS (float): scaling factor for noise in stimulus selection phase
         @alphaRS (float): boundary separation for response selection phase 
-        @betaRS (float): inital bias for response selection phase 
-        @delta_target (float): drift rate for target arrow during response selection BEFORE stimulus is selected 
-        @delta_flanker (float): drift rate for flanker arrows during response selection BEFORE stimulus is selected
-        @deltaRS (float): drift rate for the reponse selection phase after a stimulus (either flanker or target) has been selected
+        @betaRS (float): initial bias for response selection phase 
+        @etaS1 (float): scaling factor for noise in first response selection phase
+        @etaS2 (float): scaling factor for noise in second response selection phase
+        @eta_r (float): decay rate for noise scaling
         @tau (float): non-decision time
         @dt (float): change in time 
         @var (float): variance

--- a/flexddm/models/mSSP.py
+++ b/flexddm/models/mSSP.py
@@ -63,9 +63,10 @@ class mSSP(Model):
         Performs simulations for SSP model.
         @alpha (float): boundary separation
         @beta (float): initial bias
-        @p (float): perceptual input of the stimulus
+        @eta (float): scaling factor for noise
+        @eta_r (float): rate of change of noise scaling factor
         @sd_0 (float): initial standard deviation of the Gaussian distribution describing the attentional spotlight 
-        @sd_r (float): shrinking rate of the standard deviation of the Guassian distribution describing the attentional spotlight
+        @sd_r (float): shrinking rate of the standard deviation of the Gaussian distribution describing the attentional spotlight
         @tau (float): non-decision time
         @dt (float): change in time 
         @var (float): variance

--- a/flexddm/models/mSSP.py
+++ b/flexddm/models/mSSP.py
@@ -96,7 +96,7 @@ class mSSP(Model):
                     sd = 0.001
                 s_ta = ((1 + math.erf((.5 - 0) / sd / np.sqrt(2))) / 2) - ((1 + math.erf((-.5 - 0) / sd / np.sqrt(2))) / 2)
                 s_fl = 1 - s_ta
-                delta_noise = np.random.choice(noise)
+                delta_noise = np.random.choice(noise) * np.sqrt(dt)
                 delta_noise = delta_noise*(np.exp(-1*(eta_r/2)*((t-tau))))
                 if congruencylist[n] == 'incongruent':
                     delta = s_ta*p - s_fl*p

--- a/flexddm/models/mSSPit.py
+++ b/flexddm/models/mSSPit.py
@@ -93,7 +93,7 @@ class mSSPit(Model):
                     sd = 0.001
                 s_ta = ((1 + math.erf((.5 - 0) / sd / np.sqrt(2))) / 2) - ((1 + math.erf((-.5 - 0) / sd / np.sqrt(2))) / 2)
                 s_fl = 1 - s_ta
-                delta_noise = np.random.choice(noise)
+                delta_noise = np.random.choice(noise) * np.sqrt(dt)
                 delta_noise = delta_noise*(np.exp(-1*(eta_r/2)*((t-tau))))
                 if congruencylist[n] == 'incongruent':
                     delta = s_ta*p - s_fl*p

--- a/flexddm/models/mSSPit.py
+++ b/flexddm/models/mSSPit.py
@@ -61,7 +61,8 @@ class mSSPit(Model):
         Performs simulations for SSP model.
         @alpha (float): boundary separation
         @beta (float): initial bias
-        @p (float): perceptual input of the stimulus
+        @eta (float): noise scaling factor
+        @eta_r (float): noise reduction rate
         @sd_0_sd_r_ratio (float): ratio of the initial standard deviation of the Gaussian distribution describing the attentional spotlight and shrinking rate (i.e. interference time) 
         @tau (float): non-decision time
         @dt (float): change in time 


### PR DESCRIPTION
The correct formula for the Wiener process is:

$$
dW = \mathcal{N}(0, \sqrt{dt})
$$

Where:
- $dW$: Increment of the Wiener process.
- $\mathcal{N}(0, \sqrt{dt})$: A random variable sampled from a normal distribution with mean 0 and standard deviation $\sqrt{dt}$.

If $\sqrt{dt}$ is missing, the scaling of the variance with time is incorrect, leading to inconsistent results when $dt$ changes.

---

Here’s Python code to simulate the Wiener process correctly:

```python
evidence += delta*dt + np.random.normal() * np.sqrt(dt) * var
```
